### PR TITLE
Change the class name of the migration

### DIFF
--- a/updates/20220314_000003_add_whitelist_column_to_credentials_table.php
+++ b/updates/20220314_000003_add_whitelist_column_to_credentials_table.php
@@ -8,7 +8,7 @@ use October\Rain\Database\Schema\Blueprint;
 use October\Rain\Database\Updates\Migration;
 use October\Rain\Support\Facades\Schema;
 
-final class CreateTables extends Migration
+final class CreateTables2 extends Migration
 {
     public function up(): void
     {


### PR DESCRIPTION
Hi,

Thanks for a great plugin!

While installing the plugin I received `Cannot declare class Vdlp\BasicAuthentication\Updates\CreateTables, because the name is already in use`. Doing anything would work but I have added `2` :)

Best regards,

Tomasz Strojny